### PR TITLE
Remove CLI dependencies from package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,20 @@
 
 This repository contains a Model Context Protocol (MCP) server that enables Claude to compile and audit smart contract code. The server exposes tools for Solidity compilation, Slither analysis, Circom compilation, and Circomspect auditing.
 
+## Prerequisites
+
+The server relies on external CLI tools:
+
+- `circom` for compiling circuits
+- `circomspect` for auditing Circom code
+- `slither` for Solidity security analysis
+
+Install them separately and ensure they are on your `PATH`. For example, Circom can be installed via Cargo:
+
+```bash
+cargo install --locked --git https://github.com/iden3/circom.git
+```
+
 ## Available Tools
 
 - `compile_solidity`: Compile Solidity contracts using solc

--- a/package.json
+++ b/package.json
@@ -17,10 +17,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.6.1",
-    "solc": "^0.8.24",
-    "circom": "^2.1.6",
-    "circomspect": "^0.2.4",
-    "slither-analyzer": "^0.10.0"
+    "solc": "^0.8.24"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",


### PR DESCRIPTION
## Summary
- remove circom, circomspect, and slither-analyzer from NPM deps
- document external CLI prerequisites for circuit compilation and auditing

## Testing
- `npm test` *(fails: Cannot find type definition file for 'node')*


------
https://chatgpt.com/codex/tasks/task_e_68acbfdff8dc832db4d1870c30d684bc