### PR TITLE
feat: allow configurable circom paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The server relies on external CLI tools:
 - `circomspect` for auditing Circom code
 - `slither` for Solidity security analysis
 
-Install them separately and ensure they are on your `PATH`. For example, Circom can be installed via Cargo:
+Install them separately and ensure they are on your `PATH`. If they are installed elsewhere, set the `CIRCOM_PATH` and `CIRCOMSPECT_PATH` environment variables to point to the binaries. For example, Circom can be installed via Cargo:
 
 ```bash
 cargo install --locked --git https://github.com/iden3/circom.git


### PR DESCRIPTION
## Summary
- allow specifying Circom and Circomspect command paths via environment variables
- document CIRCOM_PATH and CIRCOMSPECT_PATH configuration

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68acc1c057fc832da833076740295de5