### PR TITLE
Handle missing Slither executable

### DIFF
--- a/dist/handlers/devtools.js
+++ b/dist/handlers/devtools.js
@@ -27,12 +27,27 @@ export const compileSolidityHandler = async (input) => {
 };
 export const securityAuditHandler = async (input) => {
     try {
+        if (!input.file) {
+            return createErrorResponse("No file path provided");
+        }
+        if (!fs.existsSync(input.file)) {
+            return createErrorResponse(`File not found: ${input.file}`);
+        }
+        // Verify slither is available before attempting to run it
+        try {
+            await exec("command -v slither");
+        }
+        catch {
+            return createErrorResponse("Slither is not installed or not found in PATH");
+        }
         const { stdout, stderr } = await exec(`slither ${input.file}`);
         const output = stdout || stderr;
         return createSuccessResponse(output.trim());
     }
     catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
+        const error = err;
+        const stderr = error?.stderr?.toString().trim();
+        const message = stderr || (err instanceof Error ? err.message : String(err));
         return createErrorResponse(`Slither failed: ${message}`);
     }
 };

--- a/src/handlers/devtools.ts
+++ b/src/handlers/devtools.ts
@@ -30,11 +30,27 @@ export const compileSolidityHandler = async (input: { source: string }): Promise
 
 export const securityAuditHandler = async (input: { file: string }): Promise<ToolResultSchema> => {
   try {
+    if (!input.file) {
+      return createErrorResponse("No file path provided");
+    }
+    if (!fs.existsSync(input.file)) {
+      return createErrorResponse(`File not found: ${input.file}`);
+    }
+
+    // Verify slither is available before attempting to run it
+    try {
+      await exec("command -v slither");
+    } catch {
+      return createErrorResponse("Slither is not installed or not found in PATH");
+    }
+
     const { stdout, stderr } = await exec(`slither ${input.file}`);
     const output = stdout || stderr;
     return createSuccessResponse(output.trim());
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
+    const error: any = err;
+    const stderr = error?.stderr?.toString().trim();
+    const message = stderr || (err instanceof Error ? err.message : String(err));
     return createErrorResponse(`Slither failed: ${message}`);
   }
 };

--- a/tests/tools.test.js
+++ b/tests/tools.test.js
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
-import { compileSolidityHandler, compileCircomHandler } from '../dist/handlers/devtools.js';
+import { compileSolidityHandler, compileCircomHandler, securityAuditHandler } from '../dist/handlers/devtools.js';
 
 describe('Tool Handlers', () => {
   it('compileSolidityHandler returns result structure', async () => {
@@ -13,5 +13,10 @@ describe('Tool Handlers', () => {
     const circuit = 'template Main() { signal output out; out <== 1; } component main = Main();';
     const res = await compileCircomHandler({ source: circuit });
     assert.ok(typeof res.isError === 'boolean');
+  });
+
+  it('securityAuditHandler returns error for missing file', async () => {
+    const res = await securityAuditHandler({ file: 'nonexistent.sol' });
+    assert.strictEqual(res.isError, true);
   });
 });


### PR DESCRIPTION
## Summary
- add validation and clearer errors when running Slither audits
- include regression test for missing Solidity file path

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68acc235cfb0832da153beb3c497ae6b