### PR TITLE
Handle missing circomspect executable

### DIFF
--- a/dist/handlers/devtools.js
+++ b/dist/handlers/devtools.js
@@ -56,7 +56,14 @@ export const auditCircomHandler = async (input) => {
         return createSuccessResponse(output.trim());
     }
     catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
+        const e = err;
+        const stderr = e?.stderr?.toString() ?? "";
+        const notFound = e?.code === 127 || /not found/i.test(stderr);
+        const message = notFound
+            ? "circomspect executable not found. Please install circomspect and ensure it is in your PATH."
+            : e instanceof Error
+                ? e.message
+                : String(e);
         return createErrorResponse(`circomspect failed: ${message}`);
     }
 };

--- a/src/handlers/devtools.ts
+++ b/src/handlers/devtools.ts
@@ -58,7 +58,14 @@ export const auditCircomHandler = async (input: { file: string }): Promise<ToolR
     const output = stdout || stderr;
     return createSuccessResponse(output.trim());
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
+    const e = err as any;
+    const stderr = e?.stderr?.toString() ?? "";
+    const notFound = e?.code === 127 || /not found/i.test(stderr);
+    const message = notFound
+      ? "circomspect executable not found. Please install circomspect and ensure it is in your PATH."
+      : e instanceof Error
+        ? e.message
+        : String(e);
     return createErrorResponse(`circomspect failed: ${message}`);
   }
 };


### PR DESCRIPTION
## Summary
- Provide clear error when `circomspect` binary is missing for Circom audits

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68acc29ac238832db36a050f66d398ad