### PR TITLE
Handle missing source in security audit calls

### DIFF
--- a/dist/handlers/devtools.js
+++ b/dist/handlers/devtools.js
@@ -47,9 +47,13 @@ export const compileSolidityHandler = async (input) => {
 };
 export const securityAuditHandler = async (input) => {
     try {
+        const source = input.source ?? input.file;
+        if (typeof source !== "string") {
+            return createErrorResponse("No source code provided");
+        }
         const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "slither-"));
         const filePath = path.join(tmpDir, "Contract.sol");
-        fs.writeFileSync(filePath, input.source);
+        fs.writeFileSync(filePath, source);
         // Verify slither is available before attempting to run it
         try {
             await exec("command -v slither");

--- a/dist/tools.js
+++ b/dist/tools.js
@@ -17,9 +17,13 @@ export const tools = [
         inputSchema: {
             type: "object",
             properties: {
-                source: { type: "string" }
+                source: { type: "string" },
+                file: { type: "string" }
             },
-            required: ["source"]
+            anyOf: [
+                { required: ["source"] },
+                { required: ["file"] }
+            ]
         }
     },
     {

--- a/src/handlers/devtools.ts
+++ b/src/handlers/devtools.ts
@@ -49,11 +49,16 @@ export const compileSolidityHandler = async (input: { source: string }): Promise
   }
 };
 
-export const securityAuditHandler = async (input: { source: string }): Promise<ToolResultSchema> => {
+export const securityAuditHandler = async (input: { source?: string; file?: string }): Promise<ToolResultSchema> => {
   try {
+    const source = input.source ?? input.file;
+    if (typeof source !== "string") {
+      return createErrorResponse("No source code provided");
+    }
+
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "slither-"));
     const filePath = path.join(tmpDir, "Contract.sol");
-    fs.writeFileSync(filePath, input.source);
+    fs.writeFileSync(filePath, source);
 
     // Verify slither is available before attempting to run it
     try {

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -23,9 +23,13 @@ export const tools = [
     inputSchema: {
       type: "object",
       properties: {
-        source: { type: "string" }
+        source: { type: "string" },
+        file: { type: "string" }
       },
-      required: ["source"]
+      anyOf: [
+        { required: ["source"] },
+        { required: ["file"] }
+      ]
     }
   },
   {

--- a/tests/tools.test.js
+++ b/tests/tools.test.js
@@ -19,8 +19,8 @@ describe('Tool Handlers', () => {
   });
 
   it('securityAuditHandler returns result structure', async () => {
-    const source = 'pragma solidity ^0.8.0; contract A { function f() public pure returns(uint){return 1;} }';
-    const res = await securityAuditHandler({ source });
+    const file = 'pragma solidity ^0.8.0; contract A { function f() public pure returns(uint){return 1;} }';
+    const res = await securityAuditHandler({ file });
     assert.ok(typeof res.isError === 'boolean');
   });
 });


### PR DESCRIPTION
## Summary
- allow `security_audit` tool to accept code via `source` or `file` fields and emit clear error when none provided
- document optional `file` field in security audit tool schema
- update tests to exercise `file` input

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68acc734af54832db79e7a7a14480395