### PR TITLE
Handle missing circom binary more clearly

### DIFF
--- a/dist/handlers/devtools.js
+++ b/dist/handlers/devtools.js
@@ -74,7 +74,20 @@ export const compileCircomHandler = async (input) => {
         const filePath = path.join(tmpDir, "circuit.circom");
         fs.writeFileSync(filePath, input.source);
         const circomCmd = resolveCmd("circom", "CIRCOM_PATH");
-        await exec(`${circomCmd} ${filePath} --wasm --r1cs -o ${tmpDir}`);
+        try {
+            await exec(`${circomCmd} ${filePath} --wasm --r1cs -o ${tmpDir}`);
+        }
+        catch (e) {
+            const error = e;
+            const stderr = error?.stderr?.toString() ?? "";
+            const notFound = error?.code === 127 || /not found/i.test(stderr);
+            const message = notFound
+                ? "circom executable not found. Please install circom and ensure it is in your PATH."
+                : error instanceof Error
+                    ? error.message
+                    : String(error);
+            return createErrorResponse(`Circom compilation failed: ${message}`);
+        }
         return createSuccessResponse(`Circuit compiled to ${tmpDir}`);
     }
     catch (err) {


### PR DESCRIPTION
## Summary
- detect when `circom` executable is missing
- return a helpful error instead of failing with command not found

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68acc780d728832d99f18bdd529e8cd8