### PR TITLE
feat: support file-based circom audits

### DIFF
--- a/dist/handlers/devtools.js
+++ b/dist/handlers/devtools.js
@@ -84,9 +84,13 @@ export const compileCircomHandler = async (input) => {
 };
 export const auditCircomHandler = async (input) => {
     try {
+        const source = input.source ?? input.file;
+        if (!source) {
+            return createErrorResponse("No circuit source provided");
+        }
         const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "circom-"));
         const filePath = path.join(tmpDir, "circuit.circom");
-        fs.writeFileSync(filePath, input.source);
+        fs.writeFileSync(filePath, source);
         const circomspectCmd = resolveCmd("circomspect", "CIRCOMSPECT_PATH");
         const { stdout, stderr } = await exec(`${circomspectCmd} ${filePath}`);
         const output = stdout || stderr;

--- a/dist/tools.js
+++ b/dist/tools.js
@@ -39,9 +39,9 @@ export const tools = [
         inputSchema: {
             type: "object",
             properties: {
-                source: { type: "string" }
+                file: { type: "string" }
             },
-            required: ["source"]
+            required: ["file"]
         }
     }
 ];

--- a/src/handlers/devtools.ts
+++ b/src/handlers/devtools.ts
@@ -87,11 +87,18 @@ export const compileCircomHandler = async (input: { source: string }): Promise<T
   }
 };
 
-export const auditCircomHandler = async (input: { source: string }): Promise<ToolResultSchema> => {
+export const auditCircomHandler = async (
+  input: { source?: string; file?: string }
+): Promise<ToolResultSchema> => {
   try {
+    const source = input.source ?? input.file;
+    if (!source) {
+      return createErrorResponse("No circuit source provided");
+    }
+
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "circom-"));
     const filePath = path.join(tmpDir, "circuit.circom");
-    fs.writeFileSync(filePath, input.source);
+    fs.writeFileSync(filePath, source);
 
     const circomspectCmd = resolveCmd("circomspect", "CIRCOMSPECT_PATH");
     const { stdout, stderr } = await exec(`${circomspectCmd} ${filePath}`);

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -45,9 +45,9 @@ export const tools = [
     inputSchema: {
       type: "object",
       properties: {
-        source: { type: "string" }
+        file: { type: "string" }
       },
-      required: ["source"]
+      required: ["file"]
     }
   }
 ];

--- a/tests/tools.test.js
+++ b/tests/tools.test.js
@@ -1,6 +1,11 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
-import { compileSolidityHandler, compileCircomHandler, securityAuditHandler } from '../dist/handlers/devtools.js';
+import {
+  compileSolidityHandler,
+  compileCircomHandler,
+  securityAuditHandler,
+  auditCircomHandler
+} from '../dist/handlers/devtools.js';
 
 describe('Tool Handlers', () => {
   it('compileSolidityHandler compiles successfully', async () => {
@@ -21,6 +26,12 @@ describe('Tool Handlers', () => {
   it('securityAuditHandler returns result structure', async () => {
     const source = 'pragma solidity ^0.8.0; contract A { function f() public pure returns(uint){return 1;} }';
     const res = await securityAuditHandler({ source });
+    assert.ok(typeof res.isError === 'boolean');
+  });
+
+  it('auditCircomHandler accepts file input', async () => {
+    const circuit = 'template Main() { signal output out; out <== 1; } component main = Main();';
+    const res = await auditCircomHandler({ file: circuit });
     assert.ok(typeof res.isError === 'boolean');
   });
 });


### PR DESCRIPTION
## Summary
- accept `file` input for Circom security audits
- document `audit_circom` tool with `file` schema
- cover Circom audit interface in tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68acc7a80aa4832d9d4e7bc2aa62a56a