### PR TITLE
Require filename with source for audits

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MCP Server for Smart Contract Tools
 
-This repository contains a Model Context Protocol (MCP) server that enables Claude to compile and audit smart contract code. The server exposes tools for Solidity compilation, Slither analysis, Circom compilation, and Circomspect auditing. Each tool accepts source code as text, writes it to a temporary file, and then invokes the appropriate compiler or analyzer.
+This repository contains a Model Context Protocol (MCP) server that enables Claude to compile and audit smart contract code. The server exposes tools for Solidity compilation, Slither analysis, Circom compilation, and Circomspect auditing. Each tool accepts source code as text, writes it to a temporary file, and then invokes the appropriate compiler or analyzer. Audit tools require both the code `source` and a `filename` so the server can create the file before running the analyzer.
 
 ## Prerequisites
 
@@ -8,7 +8,7 @@ The server relies on external CLI tools:
 
 - `circom` for compiling circuits
 - `circomspect` for auditing Circom code
-- `slither` for Solidity security analysis
+- `slither` for Solidity security analysis (install with `pip3 install slither-analyzer`)
 
 Install them separately and ensure they are on your `PATH`. If they are installed elsewhere, set the `CIRCOM_PATH` and `CIRCOMSPECT_PATH` environment variables to point to the binaries. For example, Circom can be installed via Cargo:
 
@@ -19,9 +19,9 @@ cargo install --locked --git https://github.com/iden3/circom.git
 ## Available Tools
 
 - `compile_solidity`: Compile Solidity contracts using solc
-- `security_audit`: Run Slither static analysis on Solidity source code
+ - `security_audit`: Run Slither static analysis. Provide `source` and a `filename`
 - `compile_circom`: Compile Circom circuits
-- `audit_circom`: Audit Circom source code with circomspect
+ - `audit_circom`: Audit Circom source code with circomspect. Provide `source` and a `filename`
 
 ## Running the Server
 

--- a/dist/handlers/devtools.js
+++ b/dist/handlers/devtools.js
@@ -47,13 +47,10 @@ export const compileSolidityHandler = async (input) => {
 };
 export const securityAuditHandler = async (input) => {
     try {
-        const source = input.source ?? input.file;
-        if (typeof source !== "string") {
-            return createErrorResponse("No source code provided");
-        }
         const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "slither-"));
-        const filePath = path.join(tmpDir, "Contract.sol");
-        fs.writeFileSync(filePath, source);
+        const filename = path.basename(input.filename);
+        const filePath = path.join(tmpDir, filename);
+        fs.writeFileSync(filePath, input.source);
         // Verify slither is available before attempting to run it
         try {
             await exec("command -v slither");
@@ -101,13 +98,10 @@ export const compileCircomHandler = async (input) => {
 };
 export const auditCircomHandler = async (input) => {
     try {
-        const source = input.source ?? input.file;
-        if (!source) {
-            return createErrorResponse("No circuit source provided");
-        }
         const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "circom-"));
-        const filePath = path.join(tmpDir, "circuit.circom");
-        fs.writeFileSync(filePath, source);
+        const filename = path.basename(input.filename);
+        const filePath = path.join(tmpDir, filename);
+        fs.writeFileSync(filePath, input.source);
         const circomspectCmd = resolveCmd("circomspect", "CIRCOMSPECT_PATH");
         const { stdout, stderr } = await exec(`${circomspectCmd} ${filePath}`);
         const output = stdout || stderr;

--- a/dist/tools.js
+++ b/dist/tools.js
@@ -18,12 +18,9 @@ export const tools = [
             type: "object",
             properties: {
                 source: { type: "string" },
-                file: { type: "string" }
+                filename: { type: "string" }
             },
-            anyOf: [
-                { required: ["source"] },
-                { required: ["file"] }
-            ]
+            required: ["source", "filename"]
         }
     },
     {
@@ -43,9 +40,10 @@ export const tools = [
         inputSchema: {
             type: "object",
             properties: {
-                file: { type: "string" }
+                source: { type: "string" },
+                filename: { type: "string" }
             },
-            required: ["file"]
+            required: ["source", "filename"]
         }
     }
 ];

--- a/src/handlers/devtools.ts
+++ b/src/handlers/devtools.ts
@@ -49,16 +49,14 @@ export const compileSolidityHandler = async (input: { source: string }): Promise
   }
 };
 
-export const securityAuditHandler = async (input: { source?: string; file?: string }): Promise<ToolResultSchema> => {
+export const securityAuditHandler = async (
+  input: { source: string; filename: string }
+): Promise<ToolResultSchema> => {
   try {
-    const source = input.source ?? input.file;
-    if (typeof source !== "string") {
-      return createErrorResponse("No source code provided");
-    }
-
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "slither-"));
-    const filePath = path.join(tmpDir, "Contract.sol");
-    fs.writeFileSync(filePath, source);
+    const filename = path.basename(input.filename);
+    const filePath = path.join(tmpDir, filename);
+    fs.writeFileSync(filePath, input.source);
 
     // Verify slither is available before attempting to run it
     try {
@@ -105,17 +103,13 @@ export const compileCircomHandler = async (input: { source: string }): Promise<T
 };
 
 export const auditCircomHandler = async (
-  input: { source?: string; file?: string }
+  input: { source: string; filename: string }
 ): Promise<ToolResultSchema> => {
   try {
-    const source = input.source ?? input.file;
-    if (!source) {
-      return createErrorResponse("No circuit source provided");
-    }
-
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "circom-"));
-    const filePath = path.join(tmpDir, "circuit.circom");
-    fs.writeFileSync(filePath, source);
+    const filename = path.basename(input.filename);
+    const filePath = path.join(tmpDir, filename);
+    fs.writeFileSync(filePath, input.source);
 
     const circomspectCmd = resolveCmd("circomspect", "CIRCOMSPECT_PATH");
     const { stdout, stderr } = await exec(`${circomspectCmd} ${filePath}`);

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -24,12 +24,9 @@ export const tools = [
       type: "object",
       properties: {
         source: { type: "string" },
-        file: { type: "string" }
+        filename: { type: "string" }
       },
-      anyOf: [
-        { required: ["source"] },
-        { required: ["file"] }
-      ]
+      required: ["source", "filename"]
     }
   },
   {
@@ -49,9 +46,10 @@ export const tools = [
     inputSchema: {
       type: "object",
       properties: {
-        file: { type: "string" }
+        source: { type: "string" },
+        filename: { type: "string" }
       },
-      required: ["file"]
+      required: ["source", "filename"]
     }
   }
 ];

--- a/tests/tools.test.js
+++ b/tests/tools.test.js
@@ -24,14 +24,14 @@ describe('Tool Handlers', () => {
   });
 
   it('securityAuditHandler returns result structure', async () => {
-    const file = 'pragma solidity ^0.8.0; contract A { function f() public pure returns(uint){return 1;} }';
-    const res = await securityAuditHandler({ file });
+    const source = 'pragma solidity ^0.8.0; contract A { function f() public pure returns(uint){return 1;} }';
+    const res = await securityAuditHandler({ source, filename: 'Contract.sol' });
     assert.ok(typeof res.isError === 'boolean');
   });
 
-  it('auditCircomHandler accepts file input', async () => {
+  it('auditCircomHandler returns result structure', async () => {
     const circuit = 'template Main() { signal output out; out <== 1; } component main = Main();';
-    const res = await auditCircomHandler({ file: circuit });
+    const res = await auditCircomHandler({ source: circuit, filename: 'circuit.circom' });
     assert.ok(typeof res.isError === 'boolean');
   });
 });


### PR DESCRIPTION
## Summary
- standardize Slither and Circomspect audits to require both source and filename inputs
- update schemas, handlers, docs, and tests to create files from provided code before invoking analyzers

## Testing
- `pip3 install slither-analyzer` *(fails: Could not find a version that satisfies the requirement slither-analyzer)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68accc7896e4832dbc4c8448a75a0c94