### PR TITLE
Fix slither handler to validate filename and run on directory

### DIFF
--- a/dist/handlers/devtools.js
+++ b/dist/handlers/devtools.js
@@ -47,6 +47,9 @@ export const compileSolidityHandler = async (input) => {
 };
 export const securityAuditHandler = async (input) => {
     try {
+        if (!input.filename) {
+            return createErrorResponse("Filename is required for Slither analysis");
+        }
         const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "slither-"));
         const filename = path.basename(input.filename);
         const filePath = path.join(tmpDir, filename);
@@ -58,7 +61,7 @@ export const securityAuditHandler = async (input) => {
         catch {
             return createErrorResponse("Slither is not installed or not found in PATH");
         }
-        const { stdout, stderr } = await exec(`slither ${filePath}`);
+        const { stdout, stderr } = await exec(`slither ${tmpDir}`);
         const output = stdout || stderr;
         return createSuccessResponse(output.trim());
     }

--- a/src/handlers/devtools.ts
+++ b/src/handlers/devtools.ts
@@ -50,9 +50,12 @@ export const compileSolidityHandler = async (input: { source: string }): Promise
 };
 
 export const securityAuditHandler = async (
-  input: { source: string; filename: string }
+  input: { source: string; filename?: string }
 ): Promise<ToolResultSchema> => {
   try {
+    if (!input.filename) {
+      return createErrorResponse("Filename is required for Slither analysis");
+    }
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "slither-"));
     const filename = path.basename(input.filename);
     const filePath = path.join(tmpDir, filename);
@@ -65,7 +68,7 @@ export const securityAuditHandler = async (
       return createErrorResponse("Slither is not installed or not found in PATH");
     }
 
-    const { stdout, stderr } = await exec(`slither ${filePath}`);
+    const { stdout, stderr } = await exec(`slither ${tmpDir}`);
     const output = stdout || stderr;
     return createSuccessResponse(output.trim());
   } catch (err) {


### PR DESCRIPTION
## Summary
- Validate `filename` before auditing with Slither
- Run Slither on the temporary directory containing the Solidity file
- Regenerate compiled JavaScript

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68acdc2a0d40832d9e8dabcf139b56d4