### PR TITLE
feat: restore file-based solidity and slither tools

### DIFF
--- a/dist/tools.js
+++ b/dist/tools.js
@@ -6,7 +6,8 @@ export const tools = [
         inputSchema: {
             type: "object",
             properties: {
-                source: { type: "string" }
+                source: { type: "string" },
+                filename: { type: "string" }
             },
             required: ["source"]
         }
@@ -20,7 +21,7 @@ export const tools = [
                 source: { type: "string" },
                 filename: { type: "string" }
             },
-            required: ["source", "filename"]
+            required: ["source"]
         }
     },
     {

--- a/src/handlers/devtools.ts
+++ b/src/handlers/devtools.ts
@@ -14,69 +14,160 @@ const resolveCmd = (cmd: string, envVar: string) => {
   return fs.existsSync(localPath) ? localPath : cmd;
 };
 
-export const compileSolidityHandler = async (input: { source: string }): Promise<ToolResultSchema> => {
-  try {
-    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "solidity-"));
-    const filePath = path.join(tmpDir, "Contract.sol");
-    fs.writeFileSync(filePath, input.source);
+export const compileSolidityHandler = async (
+  input: { source: string; filename?: string }
+): Promise<ToolResultSchema> => {
+  const filename = input.filename || "Contract.sol";
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "solidity-"));
+  const filePath = path.join(tmpDir, path.basename(filename));
+  fs.writeFileSync(filePath, input.source);
 
-    // `solc` is published as a CommonJS module. When importing it using
-    // dynamic `import()` in an ESM environment the actual module is
-    // available on the `default` property. Accessing `compile` directly on
-    // the imported object therefore results in `undefined` and calling it
-    // throws `solc.compile is not a function`. Normalize the import so that
-    // `solc` always references the compiler object regardless of how it is
-    // exported.
-    const solcModule: any = await import("solc");
-    const solc: any = solcModule.default || solcModule;
-    const solInput = {
-      language: "Solidity",
-      sources: { "Contract.sol": { content: fs.readFileSync(filePath, "utf8") } },
-      // The JSON standard input for solc expects the "ast" selection nested
-      // under the wildcard file key. Without this nesting the compiler throws
-      // a validation error ("settings.outputSelection." must be an object).
-      settings: { outputSelection: { "*": { "*": ["abi", "evm.bytecode"], "": ["ast"] } } }
-    };
-    const output = JSON.parse(solc.compile(JSON.stringify(solInput)));
-    if (output.errors && output.errors.some((e: any) => e.severity === "error")) {
-      const messages = output.errors.map((e: any) => e.formattedMessage).join("\n");
-      return createErrorResponse(`Compilation error: ${messages}`);
+  let stdout = "";
+  let stderr = "";
+  let success = false;
+  const errors: string[] = [];
+  const warnings: string[] = [];
+  let contracts: any = null;
+
+  try {
+    // Prefer system solc, fallback to solcjs from node_modules
+    let solcCmd = resolveCmd("solc", "SOLC_PATH");
+    try {
+      await exec(`${solcCmd} --version`);
+    } catch {
+      solcCmd = resolveCmd("solcjs", "SOLCJS_PATH");
     }
-    return createSuccessResponse(JSON.stringify(output.contracts, null, 2));
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    return createErrorResponse(`Compilation failed: ${message}`);
+
+    try {
+      const result = await exec(`${solcCmd} --combined-json abi,bin,metadata ${filePath}`);
+      stdout = result.stdout;
+      stderr = result.stderr;
+      success = true;
+    } catch (e: any) {
+      stdout = e.stdout ?? "";
+      stderr = e.stderr ?? "";
+      success = false;
+    }
+
+    if (!success) {
+      // Fallback to solc JS API
+      const solcModule: any = await import("solc");
+      const solc: any = solcModule.default || solcModule;
+      const solInput = {
+        language: "Solidity",
+        sources: { [filename]: { content: fs.readFileSync(filePath, "utf8") } },
+        settings: { outputSelection: { "*": { "*": ["abi", "evm.bytecode"], "": ["ast"] } } }
+      };
+      const output = JSON.parse(solc.compile(JSON.stringify(solInput)));
+      contracts = output.contracts || {};
+      if (output.errors) {
+        for (const e of output.errors) {
+          if (e.severity === "error") errors.push(e.formattedMessage);
+          else if (e.severity === "warning") warnings.push(e.formattedMessage);
+        }
+        success = !output.errors.some((e: any) => e.severity === "error");
+      } else {
+        success = true;
+      }
+    }
+  } catch (e: any) {
+    stderr = e.stderr ?? "";
+    errors.push(e.message ?? String(e));
+    success = false;
+  } finally {
+    fs.unlinkSync(filePath);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
   }
+
+  if (stdout && success) {
+    try {
+      const output = JSON.parse(stdout);
+      contracts = output.contracts || {};
+    } catch {
+      errors.push("Failed to parse compilation output");
+      success = false;
+    }
+  }
+
+  if (stderr && !stderr.includes("Warning:")) {
+    const lines = stderr.trim().split("\n");
+    for (const line of lines) {
+      if (line.includes("Error:")) errors.push(line.trim());
+      else if (line.includes("Warning:")) warnings.push(line.trim());
+      else if (line) errors.push(line.trim());
+    }
+  } else if (stderr) {
+    const lines = stderr.trim().split("\n");
+    for (const line of lines) {
+      if (line.includes("Warning:")) warnings.push(line.trim());
+    }
+  }
+
+  const result = { success, errors, warnings, contracts, filename };
+  return success
+    ? createSuccessResponse(JSON.stringify(result))
+    : createErrorResponse(JSON.stringify(result));
 };
 
 export const securityAuditHandler = async (
   input: { source: string; filename?: string }
 ): Promise<ToolResultSchema> => {
+  const filename = input.filename || "Contract.sol";
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "slither-"));
+  const filePath = path.join(tmpDir, path.basename(filename));
+  fs.writeFileSync(filePath, input.source);
+
+  let stdout = "";
+  let stderr = "";
+  let success = false;
+
   try {
-    if (!input.filename) {
-      return createErrorResponse("Filename is required for Slither analysis");
-    }
-    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "slither-"));
-    const filename = path.basename(input.filename);
-    const filePath = path.join(tmpDir, filename);
-    fs.writeFileSync(filePath, input.source);
-
-    // Verify slither is available before attempting to run it
     try {
-      await exec("command -v slither");
-    } catch {
-      return createErrorResponse("Slither is not installed or not found in PATH");
+      const result = await exec(`slither ${filePath} --json -`);
+      stdout = result.stdout;
+      stderr = result.stderr;
+      success = true;
+    } catch (e: any) {
+      stdout = e.stdout ?? "";
+      stderr = e.stderr ?? "";
+      success = false;
     }
-
-    const { stdout, stderr } = await exec(`slither ${tmpDir}`);
-    const output = stdout || stderr;
-    return createSuccessResponse(output.trim());
-  } catch (err) {
-    const error: any = err;
-    const stderr = error?.stderr?.toString().trim();
-    const message = stderr || (err instanceof Error ? err.message : String(err));
-    return createErrorResponse(`Slither failed: ${message}`);
+  } finally {
+    fs.unlinkSync(filePath);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
   }
+
+  let findings: any[] = [];
+  let summary: any = {};
+  const errors: string[] = [];
+
+  if (stdout) {
+    try {
+      const output = JSON.parse(stdout);
+      findings = output.results?.detectors || [];
+      const severityCounts: Record<string, number> = {};
+      for (const finding of findings) {
+        const impact = finding.impact || "unknown";
+        severityCounts[impact] = (severityCounts[impact] || 0) + 1;
+      }
+      summary = {
+        total_findings: findings.length,
+        severity_breakdown: severityCounts
+      };
+    } catch {
+      errors.push("Failed to parse Slither output");
+      success = false;
+    }
+  }
+
+  if (stderr && !success) {
+    errors.push(stderr.trim());
+  }
+
+  const result = { success, findings, summary, errors, filename };
+  return success
+    ? createSuccessResponse(JSON.stringify(result))
+    : createErrorResponse(JSON.stringify(result));
 };
 
 export const compileCircomHandler = async (input: { source: string }): Promise<ToolResultSchema> => {

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -12,7 +12,8 @@ export const tools = [
     inputSchema: {
       type: "object",
       properties: {
-        source: { type: "string" }
+        source: { type: "string" },
+        filename: { type: "string" }
       },
       required: ["source"]
     }
@@ -26,7 +27,7 @@ export const tools = [
         source: { type: "string" },
         filename: { type: "string" }
       },
-      required: ["source", "filename"]
+      required: ["source"]
     }
   },
   {

--- a/tests/tools.test.js
+++ b/tests/tools.test.js
@@ -12,9 +12,10 @@ describe('Tool Handlers', () => {
     const source = 'pragma solidity ^0.8.0; contract A { function f() public pure returns(uint){return 1;} }';
     const res = await compileSolidityHandler({ source });
     assert.equal(res.isError, false, `unexpected error: ${res.content?.[0]?.text}`);
-    // The Solidity compiler should return ABI data in the output JSON
-    const output = res.content?.[0]?.text ?? '';
-    assert.ok(output.includes('"abi"'));
+    const text = res.content?.[0]?.text ?? '';
+    const output = JSON.parse(text);
+    assert.equal(output.success, true);
+    assert.ok(output.contracts);
   });
 
   it('compileCircomHandler returns result structure', async () => {
@@ -27,6 +28,9 @@ describe('Tool Handlers', () => {
     const source = 'pragma solidity ^0.8.0; contract A { function f() public pure returns(uint){return 1;} }';
     const res = await securityAuditHandler({ source, filename: 'Contract.sol' });
     assert.ok(typeof res.isError === 'boolean');
+    const text = res.content?.[0]?.text ?? '';
+    const output = JSON.parse(text);
+    assert.equal(output.filename, 'Contract.sol');
   });
 
   it('auditCircomHandler returns result structure', async () => {


### PR DESCRIPTION
## Summary
- allow passing filenames for Solidity and Slither tools
- compile Solidity from temp files using solc/solcjs with JS fallback
- run Slither with `--json` and return structured findings
- update tests for new structured results

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ada0f7ecc0832dad5f306532045062